### PR TITLE
Updates README to correctly reflect how to install specific version of Git URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ To install a tagged version, use
 
 ```json
 "dependencies": {
-  "pmgbootstraptheme": "git@github.com:AgencyPMG/PMGBootstrapTheme.git#1.3.4"
+  "pmgbootstraptheme": "git@github.com:AgencyPMG/PMGBootstrapTheme.git#2.0.2"
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ To install a tagged version, use
 
 ```json
 "dependencies": {
-  "pmgbootstraptheme": "git@github.com:AgencyPMG/PMGBootstrapTheme.git#v1.3.4"
+  "pmgbootstraptheme": "git@github.com:AgencyPMG/PMGBootstrapTheme.git#1.3.4"
 }
 ```
 


### PR DESCRIPTION
The previous README file gave an incorrect example of how to install a specific version of a package hosted on GitHub.