### PR TITLE
Couple Small Fixes

### DIFF
--- a/assets/pmgbootstrap/_theme.scss
+++ b/assets/pmgbootstrap/_theme.scss
@@ -47,6 +47,10 @@ body {
     margin-top: -4px;
 }
 
+.navbar-brand.logo img {
+  display: inline-block;
+}
+
 .main {
     min-height: 500px;
 }

--- a/assets/pmgbootstrap/app.scss
+++ b/assets/pmgbootstrap/app.scss
@@ -2,7 +2,7 @@
  * Main App (Bootstrap + Theme)
  */
 
-$icon-font-path: "../../bower_components/bootstrap-sass/assets/fonts/bootstrap/";
+$icon-font-path: "../../bower_components/bootstrap-sass/assets/fonts/bootstrap/" !default;
 @import "variables";
 @import "bootstrap";
 @import "button";


### PR DESCRIPTION
1. Only set the icon font path if if it's not already set
2. Style logo images as `inline-block` so we don't get a break like below.
![screen shot 2017-02-20 at 10 40 08 am](https://cloud.githubusercontent.com/assets/1010392/23131694/fc1fa560-f758-11e6-861f-eba10d9e5264.png)
